### PR TITLE
Odd little bug fix. Apparently, sapply gets converted into a list whe…

### DIFF
--- a/R/perf.plot.R
+++ b/R/perf.plot.R
@@ -29,7 +29,7 @@ library(magrittr)
     groups <- hist(x, plot=F)$breaks
 
     #Use the cute sapply stuff to do the lookup.
-    buckets <- sapply(x, function(a) groups[which.min(abs(groups - a))])
+    buckets <- sapply(x, function(a) groups[which.min(abs(groups - a))]) %>% as.numeric
 
   }else{
   #If the variable is non-numeric, or the switch has been thrown.


### PR DESCRIPTION
…n the variable list includes an NA. Odd that I've never noticed that before. However quickly converting back to numeric, in this case that's always numeric, fixes it just fine.